### PR TITLE
Implement individual flap button press requirement

### DIFF
--- a/src/entities/player.py
+++ b/src/entities/player.py
@@ -40,6 +40,9 @@ class Player(Entity):
         self.flapMomentum = 1.0  # Multiplier for flap power
         self.isGrounded = False  # Whether player is on a platform
         
+        # Track previous flap key state to detect individual presses
+        self.flapKeyPressed = False
+        
         # Control keys (default to player 1)
         if playerNumber == 1:
             self.leftKey = pygame.K_LEFT
@@ -91,10 +94,12 @@ class Player(Entity):
                 if self.velocityX > 0:
                     self.velocityX = 0
         
-        # Flapping (vertical movement)
-        if keys[self.flapKey]:
+        # Flapping (vertical movement) - only flap on key press, not hold
+        if keys[self.flapKey] and not self.flapKeyPressed:
             self.flap()
-        else:
+            self.flapKeyPressed = True
+        elif not keys[self.flapKey]:
+            self.flapKeyPressed = False
             self.isFlapping = False
     
     def flap(self):
@@ -108,6 +113,10 @@ class Player(Entity):
         
         # Apply flap force with momentum multiplier
         self.velocityY -= FLAP_POWER * self.flapMomentum
+        
+        # Give an extra boost when taking off from ground
+        if self.isGrounded:
+            self.velocityY -= FLAP_POWER * 1.5  # Extra boost when taking off
         
         # Reset grounded state when flapping
         self.isGrounded = False
@@ -200,6 +209,7 @@ class Player(Entity):
         self.velocityX = 0
         self.velocityY = 0
         self.flapMomentum = 1.0
+        self.flapKeyPressed = False
         self.isGrounded = False
         
         # Reset state

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -12,10 +12,10 @@ FPS = 60
 GRAVITY = 0.5
 
 # Flying physics
-FLAP_POWER = 1.0  # Reduced initial flap power for momentum building
-FLAP_MOMENTUM_GAIN = 0.2  # How much each flap increases momentum
-MAX_FLAP_MOMENTUM = 3.0  # Maximum flap momentum multiplier
-FLAP_MOMENTUM_DECAY = 0.05  # How quickly flap momentum decays
+FLAP_POWER = 3.0  # Increased base flap power for individual button presses
+FLAP_MOMENTUM_GAIN = 0.4  # Increased momentum gain per flap
+MAX_FLAP_MOMENTUM = 3.5  # Slightly higher maximum momentum multiplier
+FLAP_MOMENTUM_DECAY = 0.03  # Slower momentum decay to maintain altitude longer
 MAX_VERTICAL_SPEED = 15
 
 # Horizontal movement physics


### PR DESCRIPTION
## Changes Made

This PR implements the requirement for individual button presses for each flap, preventing players from holding down the flap button for continuous flapping.

### Player Control Changes
- Modified player controls to require individual button presses for each flap
- Added `flapKeyPressed` tracking to prevent continuous flapping when holding the button
- Updated the `respawn` method to reset the `flapKeyPressed` flag

### Physics Adjustments
- Increased base flap power from 1.0 to 3.0 to compensate for individual button presses
- Doubled momentum gain from 0.2 to 0.4 for faster momentum building
- Increased maximum momentum multiplier from 3.0 to 3.5
- Reduced momentum decay from 0.05 to 0.03 for longer-lasting momentum
- Added extra boost when taking off from the ground (1.5x additional flap power)

These changes make the flying mechanics more skill-based while ensuring players can still take off and maintain altitude effectively with the new control scheme.